### PR TITLE
feat: finalize step() with average flow calculation and output

### DIFF
--- a/pipeline/opticalflow.py
+++ b/pipeline/opticalflow.py
@@ -82,3 +82,7 @@ class OpticalFlow:
                 self.prev_gray, gray,
                 None, 0.5, 5, 15, 3, 5, 1.2, 0
             )
+        
+        avg_flow = np.mean(flow, axis=(0, 1)).reshape(1, 2) / self.scale_factor
+        self.prev_gray = gray
+        return {"opticalFlow": avg_flow}


### PR DESCRIPTION
This pull request adds the final part of the `step()` method:

What's included:
Calculates the average flow vector from all pixels
Adjusts the values based on the scale factor
Saves the current frame for the next step
Returns the result as a 1x2 NumPy array

This completes the implementation of the new step() function.
